### PR TITLE
Feature grpc:  add howto for compilation

### DIFF
--- a/build/build_grpc_arm.sh
+++ b/build/build_grpc_arm.sh
@@ -17,7 +17,7 @@ protoc --go_out=plugins=grpc:. *.proto
 
 
 
-# install grpc from source
+# install grpc from source, first try protobuf in the next section
 # see it on https://github.com/grpc/grpc/blob/master/INSTALL.md
 
 # build pre-requisites for linux
@@ -31,11 +31,31 @@ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 cd grpc
 git submodule update --init
 # here comes cross-compile
+CPPFLAGS=-I/usr/arm-linux-gnueabihf/include LDFLAGS=-L/usr/arm-linux-gnueabihf/lib \
 make HAS_PKG_CONFIG=false CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-ld \
-LDXX=arm-linux-gnueabihf-g++ AR=arm-linux-gnueabihf-ar CPPFLAGS=-I/usr/arm-linux-gnueabihf/include LDFLAGS=-L/usr/arm-linux-gnueabihf/lib
+LDXX=arm-linux-gnueabihf-g++ AR=arm-linux-gnueabihf-ar 
 
 
+
+
+# build protobuf for arm before we try Grpc
 # Hints: issue for cross compile of protobuf, see https://github.com/google/protobuf/tree/master/src 
+# https://github.com/google/protobuf/blob/master/src/README.md
 
+# IMPORTANT: https://raspberrypi.stackexchange.com/questions/24448/cross-compiling-protobuf-for-raspberry-pi
+# To compile protoc executable binary, we should have a copy of x86 version of protoc binary
+# the one should be installed into /usr/bin/ directory
+cd ~/protobuf-2.6.0
+./configure --disable-shared
+make
+make check
+sudo make install
+cp /usr/local/bin/protoc /usr/bin/
 
+# then clean the binaries we compiled in $PWD/src/.lib/*
+make distclean
 
+# configure to compile source to a arm libaray, and make 
+./configure --host=arm-linux-gnueabihf CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ --with-protoc=/usr/bin/protoc 
+make
+make install

--- a/build/build_grpc_arm.sh
+++ b/build/build_grpc_arm.sh
@@ -27,6 +27,15 @@ apt-get install libgflags-dev libgtest-dev
 apt-get install clang libc++-dev
 
 # Cross-compile for arm, see issue on https://github.com/grpc/grpc/issues/9719
+git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
+cd grpc
+git submodule update --init
+# here comes cross-compile
+make HAS_PKG_CONFIG=false CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ LD=arm-linux-gnueabihf-ld \
+LDXX=arm-linux-gnueabihf-g++ AR=arm-linux-gnueabihf-ar CPPFLAGS=-I/usr/arm-linux-gnueabihf/include LDFLAGS=-L/usr/arm-linux-gnueabihf/lib
+
+
+# Hints: issue for cross compile of protobuf, see https://github.com/google/protobuf/tree/master/src 
 
 
 

--- a/build/build_grpc_env.sh
+++ b/build/build_grpc_env.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# install grpc package for go
+go get -u google.golang.org/grpc
+# if you can't get that package, try clone it
+git clone https://github.com/grpc/grpc-go.git $GOPATH/src/google.golang.org/grpc
+
+# download the Proto buffers binaries from github
+https://github.com/google/protobuf/releases   protoc-<version>-<platform>.zip #unzip it and got protoc application
+
+# install protobuf plugin for Go, and expose the binary
+go get -u github.com/golang/protobuf/{proto,protoc-gen-go}
+export PATH=$PATH:$GOPATH/bin
+
+# generate *.pb.go file from *.proto file
+protoc --go_out=plugins=grpc:. *.proto
+
+
+
+# install grpc from source
+# see it on https://github.com/grpc/grpc/blob/master/INSTALL.md
+
+# build pre-requisites for linux
+apt-get install build-essential autoconf libtool pkg-config
+# if build from source
+apt-get install libgflags-dev libgtest-dev
+apt-get install clang libc++-dev
+
+# Cross-compile for arm, see issue on https://github.com/grpc/grpc/issues/9719
+
+
+

--- a/build/build_on_arm.sh
+++ b/build/build_on_arm.sh
@@ -1,22 +1,24 @@
 #!/bin/sh
 
-# To cross compile on ubuntu, we need arm-linux-gnueabihf-gcc tools
+# To cross-compile for our arm on ubuntu, we need arm-linux-gnueabihf-gcc tools(ld-linux-armhf.so.x installed on arm board)
 sudo apt-get install libc6-armel-cross libc6-dev-armel-cross
 sudo apt-get install binutils-arm-linux-gnueabi
 sudo apt-get install libncurses5-dev
 
-# For different board
+# For different OS:  SYSV interpreted by /lib/ld-linux-armhf.so.x
 sudo apt-get install gcc-arm-linux-gnueabihf
 sudo apt-get install g++-arm-linux-gnueabihf
-# Or
+# Or GNU/LINUX interpreted by /lib/ld-linux.so.x
 sudo apt-get install gcc-arm-linux-gnueabi
 sudo apt-get install g++-arm-linux-gnueabi
 
 # Install libz.so.1 for dependency of libsqlitedb.so
-sudo apt-get install lib64z1 # This library should be replaced with the one which is competible to libsqlitedb.so
-							# which is provided in build directory(a linux sysV version for arm board)
+#sudo apt-get install lib64z1 
+# This library should be replaced with the one which is competible to libsqlitedb.so
+# which is provided in build directory(a linux sysV version for arm board)
 
-ln -s /usr/arm-linux-gnueabi/lib/libz.so.1.2.8 /usr/lib/gcc-cross/arm-linux-gnueabihf/5/../../../../arm-linux-gnueabihf/lib/libz.so.1
+cp libz.so.1.2.8 /usr/lib/gcc-cross/arm-linux-gnueabihf/5/
+ln -s /usr/lib/gcc-cross/arm-linux-gnueabihf/5/libz.so.1.2.8 /usr/lib/gcc-cross/arm-linux-gnueabihf/5/libz.so.1
 
 #env GOOS=linux GOARCH=arm64 go build -o elibot-server
 

--- a/build/build_on_arm.sh
+++ b/build/build_on_arm.sh
@@ -13,7 +13,8 @@ sudo apt-get install gcc-arm-linux-gnueabi
 sudo apt-get install g++-arm-linux-gnueabi
 
 # Install libz.so.1 for dependency of libsqlitedb.so
-sudo apt-get install lib64z1 # Here should replace the libz with competible one to libsqlitedb.so, which one should be compiled by ourselves
+sudo apt-get install lib64z1 # This library should be replaced with the one which is competible to libsqlitedb.so
+							# which is provided in build directory(a linux sysV version for arm board)
 
 ln -s /usr/arm-linux-gnueabi/lib/libz.so.1.2.8 /usr/lib/gcc-cross/arm-linux-gnueabihf/5/../../../../arm-linux-gnueabihf/lib/libz.so.1
 

--- a/build/cross-compile.sh
+++ b/build/cross-compile.sh
@@ -4,4 +4,5 @@
 # make HAS_PKG_CONFIG=false CC=your-gcc CXX=your-g++ LD=your-gcc LDXX=your-g++ AR=your-ar \
 # CPPFLAGS=-I/path/to/packages/include LDFLAGS=-L/path/to/packages/lib static
 
-# e.g. make HAS_PKG_CONFIG=false CC=arm-xilinx-linux-gnueabi-gcc CXX=arm-xilinx-linux-gnueabi-g++ ...
+# e.g. make HAS_PKG_CONFIG=false CC=arm-xxxx-linux-gnueabi-gcc \
+# CXX=arm-xxxx-linux-gnueabi-g++ RANLIB=arm-xxxx-linux-gnueabi-ranlib LD=arm-xxxx-linux-gnueabi-ld

--- a/build/cross-compile.sh
+++ b/build/cross-compile.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# template of cross-compile
+# make HAS_PKG_CONFIG=false CC=your-gcc CXX=your-g++ LD=your-gcc LDXX=your-g++ AR=your-ar \
+# CPPFLAGS=-I/path/to/packages/include LDFLAGS=-L/path/to/packages/lib static
+
+# e.g. make HAS_PKG_CONFIG=false CC=arm-xilinx-linux-gnueabi-gcc CXX=arm-xilinx-linux-gnueabi-g++ ...


### PR DESCRIPTION
Record the procedures for cross-compilation for arm board.
Since we have /lib/ld-linux-armhf.so.3 on that board, so we should configure all our compiler to arm-linux-gnueabihf.
